### PR TITLE
Modify url imports and remove verify is true from bookmarks formss

### DIFF
--- a/bookmarks/forms.py
+++ b/bookmarks/forms.py
@@ -7,7 +7,7 @@ from bookmarks.models import Bookmark, Page
 
 
 class BookmarkForm(forms.ModelForm):
-    url = forms.URLField(label="URL", verify_exists=False, widget=forms.TextInput(attrs={"size": 40}))
+    url = forms.URLField(label="URL", widget=forms.TextInput(attrs={"size": 40}))
     title = forms.CharField(max_length=100, widget=forms.TextInput(attrs={"size": 40}))
     keywords = forms.CharField(max_length=100, widget=forms.TextInput(attrs={"size": 40}))
     content = forms.Textarea()

--- a/bookmarks/urls.py
+++ b/bookmarks/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls.defaults import url, patterns
-
+from django.conf.urls import include, url, patterns
 
 urlpatterns = patterns("",
     url(r"^$", "bookmarks.views.bookmarks", name="all_bookmarks"),


### PR DESCRIPTION
Adding support for Django >= 1.5 by removing "verify is true" from forms.py. 

As  per [here](http://stackoverflow.com/questions/26887037/no-module-named-defaults-python-django), > "defaults" is deprecated as of Django 1.6.

 So I modified the import statement from 
`"from django.conf.urls.defaults import urls, includes, patterns"` 
to `"from django.conf.urls import urls, includes, patterns "`
